### PR TITLE
feat: Support OCI Artifact Manifest

### DIFF
--- a/content/file/file_test.go
+++ b/content/file/file_test.go
@@ -34,7 +34,6 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
 	"golang.org/x/sync/errgroup"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
@@ -2126,17 +2125,14 @@ func TestStore_Predecessors(t *testing.T) {
 		appendBlob(ocispec.MediaTypeImageIndex, indexJSON)
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, blobs ...ocispec.Descriptor) {
-		var manifest artifactspec.Manifest
-		artifactSubject := descriptor.OCIToArtifact(subject)
-		manifest.Subject = &artifactSubject
-		for _, blob := range blobs {
-			manifest.Blobs = append(manifest.Blobs, descriptor.OCIToArtifact(blob))
-		}
+		var manifest ocispec.Artifact
+		manifest.Subject = &subject
+		manifest.Blobs = append(manifest.Blobs, blobs...)
 		manifestJSON, err := json.Marshal(manifest)
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(artifactspec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
 	}
 
 	appendBlob(ocispec.MediaTypeImageConfig, []byte("config")) // Blob 0

--- a/content/graph.go
+++ b/content/graph.go
@@ -92,6 +92,21 @@ func Successors(ctx context.Context, fetcher Fetcher, node ocispec.Descriptor) (
 			nodes = append(nodes, descriptor.ArtifactToOCI(blob))
 		}
 		return nodes, nil
+	case ocispec.MediaTypeArtifactManifest:
+		content, err := FetchAll(ctx, fetcher, node)
+		if err != nil {
+			return nil, err
+		}
+
+		var manifest ocispec.Artifact
+		if err := json.Unmarshal(content, &manifest); err != nil {
+			return nil, err
+		}
+		var nodes []ocispec.Descriptor
+		if manifest.Subject != nil {
+			nodes = append(nodes, *manifest.Subject)
+		}
+		return append(nodes, manifest.Blobs...), nil
 	}
 	return nil, nil
 }

--- a/content/graph.go
+++ b/content/graph.go
@@ -74,7 +74,7 @@ func Successors(ctx context.Context, fetcher Fetcher, node ocispec.Descriptor) (
 			return nil, err
 		}
 		return index.Manifests, nil
-	case artifactspec.MediaTypeArtifactManifest:
+	case artifactspec.MediaTypeArtifactManifest: // TODO: deprecate
 		content, err := FetchAll(ctx, fetcher, node)
 		if err != nil {
 			return nil, err

--- a/content/memory/memory_test.go
+++ b/content/memory/memory_test.go
@@ -29,13 +29,11 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
 	"golang.org/x/sync/errgroup"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/internal/cas"
-	"oras.land/oras-go/v2/internal/descriptor"
 	"oras.land/oras-go/v2/internal/resolver"
 )
 
@@ -332,17 +330,14 @@ func TestStorePredecessors(t *testing.T) {
 		appendBlob(ocispec.MediaTypeImageIndex, indexJSON)
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, blobs ...ocispec.Descriptor) {
-		var manifest artifactspec.Manifest
-		artifactSubject := descriptor.OCIToArtifact(subject)
-		manifest.Subject = &artifactSubject
-		for _, blob := range blobs {
-			manifest.Blobs = append(manifest.Blobs, descriptor.OCIToArtifact(blob))
-		}
+		var manifest ocispec.Artifact
+		manifest.Subject = &subject
+		manifest.Blobs = append(manifest.Blobs, blobs...)
 		manifestJSON, err := json.Marshal(manifest)
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(artifactspec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
 	}
 
 	appendBlob(ocispec.MediaTypeImageConfig, []byte("config")) // Blob 0

--- a/content/oci/oci_test.go
+++ b/content/oci/oci_test.go
@@ -33,14 +33,12 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
 	"golang.org/x/sync/errgroup"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
 	"oras.land/oras-go/v2/content/memory"
 	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/internal/cas"
-	"oras.land/oras-go/v2/internal/descriptor"
 )
 
 // storageTracker tracks storage API counts.
@@ -671,17 +669,14 @@ func TestStore_Predecessors(t *testing.T) {
 		appendBlob(ocispec.MediaTypeImageIndex, indexJSON)
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, blobs ...ocispec.Descriptor) {
-		var manifest artifactspec.Manifest
-		artifactSubject := descriptor.OCIToArtifact(subject)
-		manifest.Subject = &artifactSubject
-		for _, blob := range blobs {
-			manifest.Blobs = append(manifest.Blobs, descriptor.OCIToArtifact(blob))
-		}
+		var manifest ocispec.Artifact
+		manifest.Subject = &subject
+		manifest.Blobs = append(manifest.Blobs, blobs...)
 		manifestJSON, err := json.Marshal(manifest)
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(artifactspec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
 	}
 
 	appendBlob(ocispec.MediaTypeImageConfig, []byte("config")) // Blob 0
@@ -786,17 +781,14 @@ func TestStore_ExistingStore(t *testing.T) {
 	}
 
 	generateArtifactManifest := func(subject ocispec.Descriptor, blobs ...ocispec.Descriptor) {
-		var manifest artifactspec.Manifest
-		artifactSubject := descriptor.OCIToArtifact(subject)
-		manifest.Subject = &artifactSubject
-		for _, blob := range blobs {
-			manifest.Blobs = append(manifest.Blobs, descriptor.OCIToArtifact(blob))
-		}
+		var manifest ocispec.Artifact
+		manifest.Subject = &subject
+		manifest.Blobs = append(manifest.Blobs, blobs...)
 		manifestJSON, err := json.Marshal(manifest)
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(artifactspec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
 	}
 
 	appendBlob(ocispec.MediaTypeImageConfig, []byte("config")) // Blob 0

--- a/example_test.go
+++ b/example_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/opencontainers/go-digest"
 	specs "github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content/memory"
 	"oras.land/oras-go/v2/content/oci"
@@ -41,23 +40,19 @@ import (
 var exampleMemoryStore oras.Target
 var remoteHost string
 var (
-	exampleManifest, _ = json.Marshal(artifactspec.Manifest{
-		MediaType:    artifactspec.MediaTypeArtifactManifest,
+	exampleManifest, _ = json.Marshal(ocispec.Artifact{
+		MediaType:    ocispec.MediaTypeArtifactManifest,
 		ArtifactType: "example/content"})
 	exampleManifestDescriptor = ocispec.Descriptor{
-		MediaType: artifactspec.MediaTypeArtifactManifest,
+		MediaType: ocispec.MediaTypeArtifactManifest,
 		Digest:    digest.Digest(digest.FromBytes(exampleManifest)),
 		Size:      int64(len(exampleManifest))}
-	exampleManifestDescriptorArtifactspec = artifactspec.Descriptor{
-		MediaType: exampleManifestDescriptor.MediaType,
-		Digest:    exampleManifestDescriptor.Digest,
-		Size:      exampleManifestDescriptor.Size}
-	exampleSignatureManifest, _ = json.Marshal(artifactspec.Manifest{
-		MediaType:    artifactspec.MediaTypeArtifactManifest,
+	exampleSignatureManifest, _ = json.Marshal(ocispec.Artifact{
+		MediaType:    ocispec.MediaTypeArtifactManifest,
 		ArtifactType: "example/signature",
-		Subject:      &exampleManifestDescriptorArtifactspec})
+		Subject:      &exampleManifestDescriptor})
 	exampleSignatureManifestDescriptor = ocispec.Descriptor{
-		MediaType: artifactspec.MediaTypeArtifactManifest,
+		MediaType: ocispec.MediaTypeArtifactManifest,
 		Digest:    digest.FromBytes(exampleSignatureManifest),
 		Size:      int64(len(exampleSignatureManifest))}
 )
@@ -122,7 +117,7 @@ func TestMain(m *testing.M) {
 		case strings.Contains(p, "/blobs/uploads/"+exampleUploadUUid) && m == "GET":
 			w.WriteHeader(http.StatusCreated)
 		case strings.Contains(p, "/manifests/"+string(exampleSignatureManifestDescriptor.Digest)):
-			w.Header().Set("Content-Type", artifactspec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
 			w.Header().Set("Docker-Content-Digest", string(exampleSignatureManifestDescriptor.Digest))
 			w.Header().Set("Content-Length", strconv.Itoa(len(exampleSignatureManifest)))
 			w.Write(exampleSignatureManifest)
@@ -130,7 +125,7 @@ func TestMain(m *testing.M) {
 			w.WriteHeader(http.StatusCreated)
 		case strings.Contains(p, "/manifests/"+string(exampleManifestDescriptor.Digest)),
 			strings.Contains(p, "/manifests/latest") && m == "HEAD":
-			w.Header().Set("Content-Type", artifactspec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
 			w.Header().Set("Docker-Content-Digest", string(exampleManifestDescriptor.Digest))
 			w.Header().Set("Content-Length", strconv.Itoa(len(exampleManifest)))
 			if m == "GET" {
@@ -317,7 +312,7 @@ func Example_copyArtifactManifestRemoteToLocal() {
 	dst := memory.New()
 	ctx := context.Background()
 
-	exampleDigest := "sha256:f9308ac4616a808210c12d049b4eb684754a5acf2c3c8d353a9fa2b3c47c274a"
+	exampleDigest := "sha256:70c29a81e235dda5c2cebb8ec06eafd3cca346cbd91f15ac74cefd98681c5b3d"
 	descriptor, err := src.Resolve(ctx, exampleDigest)
 	if err != nil {
 		panic(err)
@@ -358,5 +353,5 @@ func Example_extendedCopyArtifactAndReferrersRemoteToLocal() {
 
 	fmt.Println(desc.Digest)
 	// Output:
-	// sha256:1f3e679d4fc05dca20a699ae5af5fb2b7d481d5694aff929165d1c8b0f4c8598
+	// sha256:f396bc4d300934a39ca28ab0d5ac8a3573336d7d63c654d783a68cd1e2057662
 }

--- a/extendedcopy_test.go
+++ b/extendedcopy_test.go
@@ -68,17 +68,14 @@ func TestExtendedCopy_FullCopy(t *testing.T) {
 		appendBlob(ocispec.MediaTypeImageManifest, manifestJSON)
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, blobs ...ocispec.Descriptor) {
-		var manifest artifactspec.Manifest
-		artifactSubject := descriptor.OCIToArtifact(subject)
-		manifest.Subject = &artifactSubject
-		for _, blob := range blobs {
-			manifest.Blobs = append(manifest.Blobs, descriptor.OCIToArtifact(blob))
-		}
+		var manifest ocispec.Artifact
+		manifest.Subject = &subject
+		manifest.Blobs = append(manifest.Blobs, blobs...)
 		manifestJSON, err := json.Marshal(manifest)
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(artifactspec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
 	}
 
 	appendBlob(ocispec.MediaTypeImageConfig, []byte("config")) // Blob 0
@@ -169,17 +166,14 @@ func TestExtendedCopyGraph_FullCopy(t *testing.T) {
 		appendBlob(ocispec.MediaTypeImageIndex, indexJSON)
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, blobs ...ocispec.Descriptor) {
-		var manifest artifactspec.Manifest
-		artifactSubject := descriptor.OCIToArtifact(subject)
-		manifest.Subject = &artifactSubject
-		for _, blob := range blobs {
-			manifest.Blobs = append(manifest.Blobs, descriptor.OCIToArtifact(blob))
-		}
+		var manifest ocispec.Artifact
+		manifest.Subject = &subject
+		manifest.Blobs = append(manifest.Blobs, blobs...)
 		manifestJSON, err := json.Marshal(manifest)
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(artifactspec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
 	}
 
 	appendBlob(ocispec.MediaTypeImageConfig, []byte("config_1")) // Blob 0
@@ -377,17 +371,14 @@ func TestExtendedCopyGraph_WithDepthOption(t *testing.T) {
 		appendBlob(ocispec.MediaTypeImageIndex, indexJSON)
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, blobs ...ocispec.Descriptor) {
-		var manifest artifactspec.Manifest
-		artifactSubject := descriptor.OCIToArtifact(subject)
-		manifest.Subject = &artifactSubject
-		for _, blob := range blobs {
-			manifest.Blobs = append(manifest.Blobs, descriptor.OCIToArtifact(blob))
-		}
+		var manifest ocispec.Artifact
+		manifest.Subject = &subject
+		manifest.Blobs = append(manifest.Blobs, blobs...)
 		manifestJSON, err := json.Marshal(manifest)
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(artifactspec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
 	}
 
 	appendBlob(ocispec.MediaTypeImageConfig, []byte("config_1")) // Blob 0
@@ -512,17 +503,14 @@ func TestExtendedCopyGraph_WithFindPredecessorsOption(t *testing.T) {
 		appendBlob(ocispec.MediaTypeImageIndex, indexJSON)
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, blobs ...ocispec.Descriptor) {
-		var manifest artifactspec.Manifest
-		artifactSubject := descriptor.OCIToArtifact(subject)
-		manifest.Subject = &artifactSubject
-		for _, blob := range blobs {
-			manifest.Blobs = append(manifest.Blobs, descriptor.OCIToArtifact(blob))
-		}
+		var manifest ocispec.Artifact
+		manifest.Subject = &subject
+		manifest.Blobs = append(manifest.Blobs, blobs...)
 		manifestJSON, err := json.Marshal(manifest)
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(artifactspec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
 	}
 
 	appendBlob(ocispec.MediaTypeImageConfig, []byte("config_1")) // Blob 0
@@ -577,7 +565,7 @@ func TestExtendedCopyGraph_WithFindPredecessorsOption(t *testing.T) {
 			for _, p := range predecessors {
 				// filter media type
 				switch p.MediaType {
-				case artifactspec.MediaTypeArtifactManifest:
+				case ocispec.MediaTypeArtifactManifest:
 					filtered = append(filtered, p)
 				}
 			}

--- a/registry/remote/example_test.go
+++ b/registry/remote/example_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
 	"oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/content"
 	. "oras.land/oras-go/v2/registry/internal/doc"
@@ -45,32 +44,32 @@ const (
 	exampleLayer            = "Example layer content"
 	exampleUploadUUid       = "0bc84d80-837c-41d9-824e-1907463c53b3"
 	ManifestDigest          = "sha256:0b696106ecd0654e031f19e0a8cbd1aee4ad457d7c9cea881f07b12a930cd307"
-	ReferenceManifestDigest = "sha256:b2122d3fd728173dd6b68a0b73caa129302b78c78273ba43ead541a88169c855"
+	ReferenceManifestDigest = "sha256:6983f495f7ee70d43e571657ae8b39ca3d3ca1b0e77270fd4fbddfb19832a1cf"
 	_                       = ExampleUnplayable
 )
 
 var (
 	exampleLayerDigest        = digest.FromBytes([]byte(exampleLayer)).String()
 	exampleManifestDigest     = digest.FromBytes([]byte(exampleManifest)).String()
-	exampleManifestDescriptor = artifactspec.Descriptor{
+	exampleManifestDescriptor = ocispec.Descriptor{
 		MediaType: ocispec.MediaTypeImageManifest,
 		Digest:    digest.Digest(exampleManifestDigest),
 		Size:      int64(len(exampleManifest))}
-	exampleSignatureManifest, _ = json.Marshal(artifactspec.Manifest{
-		MediaType:    artifactspec.MediaTypeArtifactManifest,
+	exampleSignatureManifest, _ = json.Marshal(ocispec.Artifact{
+		MediaType:    ocispec.MediaTypeArtifactManifest,
 		ArtifactType: "example/signature",
 		Subject:      &exampleManifestDescriptor})
 	exampleSignatureManifestDescriptor = ocispec.Descriptor{
-		MediaType:    artifactspec.MediaTypeArtifactManifest,
+		MediaType:    ocispec.MediaTypeArtifactManifest,
 		ArtifactType: "example/signature",
 		Digest:       digest.FromBytes(exampleSignatureManifest),
 		Size:         int64(len(exampleSignatureManifest))}
-	exampleSBoMManifest, _ = json.Marshal(artifactspec.Manifest{
-		MediaType:    artifactspec.MediaTypeArtifactManifest,
+	exampleSBoMManifest, _ = json.Marshal(ocispec.Artifact{
+		MediaType:    ocispec.MediaTypeArtifactManifest,
 		ArtifactType: "example/SBoM",
 		Subject:      &exampleManifestDescriptor})
 	exampleSBoMManifestDescriptor = ocispec.Descriptor{
-		MediaType:    artifactspec.MediaTypeArtifactManifest,
+		MediaType:    ocispec.MediaTypeArtifactManifest,
 		ArtifactType: "example/SBoM",
 		Digest:       digest.FromBytes(exampleSBoMManifest),
 		Size:         int64(len(exampleSBoMManifest))}
@@ -79,17 +78,17 @@ var (
 		{exampleSignatureManifestDescriptor}, // page 1
 	}
 	blobContent    = "example blob content"
-	blobDescriptor = artifactspec.Descriptor{
+	blobDescriptor = ocispec.Descriptor{
 		MediaType: "application/tar",
 		Digest:    digest.FromBytes([]byte(blobContent)),
 		Size:      int64(len(blobContent))}
-	exampleManifestWithBlobs, _ = json.Marshal(artifactspec.Manifest{
-		MediaType:    artifactspec.MediaTypeArtifactManifest,
+	exampleManifestWithBlobs, _ = json.Marshal(ocispec.Artifact{
+		MediaType:    ocispec.MediaTypeArtifactManifest,
 		ArtifactType: "example/manifest",
-		Blobs:        []artifactspec.Descriptor{blobDescriptor},
+		Blobs:        []ocispec.Descriptor{blobDescriptor},
 		Subject:      &exampleManifestDescriptor})
 	exampleManifestWithBlobsDescriptor = ocispec.Descriptor{
-		MediaType:    artifactspec.MediaTypeArtifactManifest,
+		MediaType:    ocispec.MediaTypeArtifactManifest,
 		ArtifactType: "example/manifest",
 		Digest:       digest.FromBytes(exampleManifestWithBlobs),
 		Size:         int64(len(exampleManifestWithBlobs))}
@@ -133,25 +132,25 @@ func TestMain(m *testing.M) {
 			w.WriteHeader(http.StatusCreated)
 		case p == fmt.Sprintf("/v2/%s/manifests/%s", exampleRepositoryName, exampleSignatureManifestDescriptor.Digest) && m == "GET":
 			w.Header().Set("ORAS-Api-Version", "oras/1.0")
-			w.Header().Set("Content-Type", artifactspec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", string(exampleSignatureManifestDescriptor.Digest))
 			w.Header().Set("Content-Length", strconv.Itoa(len(exampleSignatureManifest)))
 			w.Write(exampleSignatureManifest)
 		case p == fmt.Sprintf("/v2/%s/manifests/%s", exampleRepositoryName, exampleSBoMManifestDescriptor.Digest) && m == "GET":
 			w.Header().Set("ORAS-Api-Version", "oras/1.0")
-			w.Header().Set("Content-Type", artifactspec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", string(exampleSBoMManifestDescriptor.Digest))
 			w.Header().Set("Content-Length", strconv.Itoa(len(exampleSBoMManifest)))
 			w.Write(exampleSBoMManifest)
 		case p == fmt.Sprintf("/v2/%s/manifests/%s", exampleRepositoryName, exampleManifestWithBlobsDescriptor.Digest) && m == "GET":
 			w.Header().Set("ORAS-Api-Version", "oras/1.0")
-			w.Header().Set("Content-Type", artifactspec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", string(exampleManifestWithBlobsDescriptor.Digest))
 			w.Header().Set("Content-Length", strconv.Itoa(len(exampleManifestWithBlobs)))
 			w.Write(exampleManifestWithBlobs)
 		case p == fmt.Sprintf("/v2/%s/blobs/%s", exampleRepositoryName, blobDescriptor.Digest) && m == "GET":
 			w.Header().Set("ORAS-Api-Version", "oras/1.0")
-			w.Header().Set("Content-Type", artifactspec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
 			w.Header().Set("Content-Digest", string(blobDescriptor.Digest))
 			w.Header().Set("Content-Length", strconv.Itoa(len(blobContent)))
 			w.Write([]byte(blobContent))
@@ -279,36 +278,29 @@ func ExampleRepository_Push_artifactReferenceManifest() {
 	manifest := ocispec.Manifest{
 		MediaType: ocispec.MediaTypeImageManifest,
 	}
-	manifestContent, _ := json.Marshal(manifest)
-	manifestDescriptor := artifactspec.Descriptor{
-		MediaType: ocispec.MediaTypeImageManifest,
-		Digest:    digest.FromBytes(manifestContent),
-		Size:      int64(len(manifestContent)),
+	manifestContent, err := json.Marshal(manifest)
+	if err != nil {
+		panic(err)
 	}
+	manifestDescriptor := content.NewDescriptorFromBytes(ocispec.MediaTypeImageManifest, manifestContent)
 
 	// 2. push the manifest descriptor and content
-	err = repo.Push(ctx, ocispec.Descriptor{
-		MediaType: manifestDescriptor.MediaType,
-		Digest:    manifestDescriptor.Digest,
-		Size:      manifestDescriptor.Size,
-	}, bytes.NewReader(manifestContent))
+	err = repo.Push(ctx, manifestDescriptor, bytes.NewReader(manifestContent))
 	if err != nil {
 		panic(err)
 	}
 
 	// 3. assemble the reference artifact manifest
-	referenceManifest := artifactspec.Manifest{
-		MediaType:    artifactspec.MediaTypeArtifactManifest,
+	referenceManifest := ocispec.Artifact{
+		MediaType:    ocispec.MediaTypeArtifactManifest,
 		ArtifactType: "sbom/example",
 		Subject:      &manifestDescriptor,
 	}
-	referenceManifestContent, _ := json.Marshal(referenceManifest)
-	referenceManifestDescriptor := ocispec.Descriptor{
-		MediaType: artifactspec.MediaTypeArtifactManifest,
-		Digest:    digest.FromBytes(referenceManifestContent),
-		Size:      int64(len(referenceManifestContent)),
+	referenceManifestContent, err := json.Marshal(referenceManifest)
+	if err != nil {
+		panic(err)
 	}
-
+	referenceManifestDescriptor := content.NewDescriptorFromBytes(ocispec.MediaTypeArtifactManifest, referenceManifestContent)
 	// 4. push the reference manifest descriptor and content
 	err = repo.Push(ctx, referenceManifestDescriptor, bytes.NewReader(referenceManifestContent))
 	if err != nil {
@@ -445,18 +437,12 @@ func ExampleRepository_Fetch_artifactReferenceManifest() {
 		// for each page of the results, do the following:
 		for _, referrer := range referrers {
 			// for each item in this page, pull the manifest and verify its content
-			rc, err := repo.Fetch(ctx, ocispec.Descriptor{
-				MediaType: referrer.MediaType,
-				Digest:    referrer.Digest,
-				Size:      referrer.Size})
+			rc, err := repo.Fetch(ctx, referrer)
 			if err != nil {
 				panic(err)
 			}
 			defer rc.Close() // don't forget to close
-			pulledBlob, err := content.ReadAll(rc, ocispec.Descriptor{
-				MediaType: referrer.MediaType,
-				Digest:    referrer.Digest,
-				Size:      referrer.Size})
+			pulledBlob, err := content.ReadAll(rc, referrer)
 			if err != nil {
 				panic(err)
 			}
@@ -467,8 +453,8 @@ func ExampleRepository_Fetch_artifactReferenceManifest() {
 		panic(err)
 	}
 	// Output:
-	// {"mediaType":"application/vnd.cncf.oras.artifact.manifest.v1+json","artifactType":"example/SBoM","blobs":null,"subject":{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:00e5ffa7d914b4e6aa3f1a324f37df0625ccc400be333deea5ecaa199f9eff5b","size":24}}
-	// {"mediaType":"application/vnd.cncf.oras.artifact.manifest.v1+json","artifactType":"example/signature","blobs":null,"subject":{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:00e5ffa7d914b4e6aa3f1a324f37df0625ccc400be333deea5ecaa199f9eff5b","size":24}}
+	// {"mediaType":"application/vnd.oci.artifact.manifest.v1+json","artifactType":"example/SBoM","subject":{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:00e5ffa7d914b4e6aa3f1a324f37df0625ccc400be333deea5ecaa199f9eff5b","size":24}}
+	// {"mediaType":"application/vnd.oci.artifact.manifest.v1+json","artifactType":"example/signature","subject":{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:00e5ffa7d914b4e6aa3f1a324f37df0625ccc400be333deea5ecaa199f9eff5b","size":24}}
 }
 
 // ExampleRepository_fetchArtifactBlobs gives an example of pulling the blobs
@@ -481,7 +467,7 @@ func ExampleRepository_fetchArtifactBlobs() {
 	ctx := context.Background()
 
 	// 1. Fetch the artifact manifest by digest.
-	exampleDigest := "sha256:73bccdadf23b5df306bf77b23e1b00944c7bbce44cf63439afe15507a73413b5"
+	exampleDigest := "sha256:1907bb31b7add4d47d74d2c5c1c10d67b757a996f8e8186e562113bc9879b1a3"
 	descriptor, rc, err := repo.FetchReference(ctx, exampleDigest)
 	if err != nil {
 		panic(err)
@@ -495,16 +481,12 @@ func ExampleRepository_fetchArtifactBlobs() {
 	fmt.Println(string(pulledContent))
 
 	// 2. Parse the pulled manifest and fetch its blobs.
-	var pulledManifest artifactspec.Manifest
+	var pulledManifest ocispec.Artifact
 	if err := json.Unmarshal(pulledContent, &pulledManifest); err != nil {
 		panic(err)
 	}
 	for _, blob := range pulledManifest.Blobs {
-		content, err := content.FetchAll(ctx, repo, ocispec.Descriptor{
-			MediaType: blob.MediaType,
-			Digest:    blob.Digest,
-			Size:      blob.Size,
-		})
+		content, err := content.FetchAll(ctx, repo, blob)
 		if err != nil {
 			panic(err)
 		}
@@ -512,7 +494,7 @@ func ExampleRepository_fetchArtifactBlobs() {
 	}
 
 	// Output:
-	// {"mediaType":"application/vnd.cncf.oras.artifact.manifest.v1+json","artifactType":"example/manifest","blobs":[{"mediaType":"application/tar","digest":"sha256:8d6497c94694a292c04f85cd055d8b5c03eda835dd311e20dfbbf029ff9748cc","size":20}],"subject":{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:00e5ffa7d914b4e6aa3f1a324f37df0625ccc400be333deea5ecaa199f9eff5b","size":24}}
+	// {"mediaType":"application/vnd.oci.artifact.manifest.v1+json","artifactType":"example/manifest","blobs":[{"mediaType":"application/tar","digest":"sha256:8d6497c94694a292c04f85cd055d8b5c03eda835dd311e20dfbbf029ff9748cc","size":20}],"subject":{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"sha256:00e5ffa7d914b4e6aa3f1a324f37df0625ccc400be333deea5ecaa199f9eff5b","size":24}}
 	// example blob content
 }
 

--- a/registry/remote/example_test.go
+++ b/registry/remote/example_test.go
@@ -249,14 +249,10 @@ func ExampleRepository_Push() {
 	ctx := context.Background()
 
 	// 1. assemble a descriptor
-	content := []byte("Example layer content")
-	descriptor := ocispec.Descriptor{
-		MediaType: ocispec.MediaTypeImageLayer, // Set media type
-		Digest:    digest.FromBytes(content),   // Calculate digest
-		Size:      int64(len(content)),         // Include content size
-	}
+	layer := []byte("Example layer content")
+	descriptor := content.NewDescriptorFromBytes(ocispec.MediaTypeImageLayer, layer)
 	// 2. push the descriptor and blob content
-	err = repo.Push(ctx, descriptor, bytes.NewReader(content))
+	err = repo.Push(ctx, descriptor, bytes.NewReader(layer))
 	if err != nil {
 		panic(err)
 	}
@@ -749,13 +745,6 @@ func Example_pushAndTag() {
 	//   |                                                   |
 	//   +--------+ localhost:5000/example/registry +--------+
 
-	generateDescriptor := func(mediaType string, blob []byte) (desc ocispec.Descriptor) {
-		return ocispec.Descriptor{
-			MediaType: mediaType,
-			Digest:    digest.FromBytes(blob), // Calculate digest
-			Size:      int64(len(blob)),       // Include blob size
-		}
-	}
 	generateManifest := func(config ocispec.Descriptor, layers ...ocispec.Descriptor) ([]byte, error) {
 		content := ocispec.Manifest{
 			Config:    config,
@@ -764,17 +753,16 @@ func Example_pushAndTag() {
 		}
 		return json.Marshal(content)
 	}
-
 	// 1. assemble descriptors and manifest
 	layerBlob := []byte("Hello layer")
-	layerDesc := generateDescriptor(ocispec.MediaTypeImageLayer, layerBlob)
+	layerDesc := content.NewDescriptorFromBytes(ocispec.MediaTypeImageLayer, layerBlob)
 	configBlob := []byte("Hello config")
-	configDesc := generateDescriptor(ocispec.MediaTypeImageConfig, configBlob)
+	configDesc := content.NewDescriptorFromBytes(ocispec.MediaTypeImageConfig, configBlob)
 	manifestBlob, err := generateManifest(configDesc, layerDesc)
 	if err != nil {
 		panic(err)
 	}
-	manifestDesc := generateDescriptor(ocispec.MediaTypeImageManifest, manifestBlob)
+	manifestDesc := content.NewDescriptorFromBytes(ocispec.MediaTypeImageManifest, manifestBlob)
 
 	// 2. push and tag
 	err = repo.Push(ctx, layerDesc, bytes.NewReader(layerBlob))

--- a/registry/remote/manifest.go
+++ b/registry/remote/manifest.go
@@ -29,7 +29,8 @@ var defaultManifestMediaTypes = []string{
 	docker.MediaTypeManifestList,
 	ocispec.MediaTypeImageManifest,
 	ocispec.MediaTypeImageIndex,
-	artifactspec.MediaTypeArtifactManifest,
+	artifactspec.MediaTypeArtifactManifest, // TODO: deprecate
+	ocispec.MediaTypeArtifactManifest,
 }
 
 // defaultManifestAcceptHeader is the default set in the `Accept` header for

--- a/registry/remote/repository_test.go
+++ b/registry/remote/repository_test.go
@@ -35,7 +35,6 @@ import (
 	"github.com/opencontainers/distribution-spec/specs-go/v1/extensions"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
 	"oras.land/oras-go/v2/errdef"
 	"oras.land/oras-go/v2/internal/interfaces"
 	"oras.land/oras-go/v2/registry"
@@ -869,13 +868,13 @@ func TestRepository_Predecessors(t *testing.T) {
 	referrerSet := [][]ocispec.Descriptor{
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         1,
 				Digest:       digest.FromString("1"),
 				ArtifactType: "application/vnd.test",
 			},
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         2,
 				Digest:       digest.FromString("2"),
 				ArtifactType: "application/vnd.test",
@@ -883,13 +882,13 @@ func TestRepository_Predecessors(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         3,
 				Digest:       digest.FromString("3"),
 				ArtifactType: "application/vnd.test",
 			},
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         4,
 				Digest:       digest.FromString("4"),
 				ArtifactType: "application/vnd.test",
@@ -897,7 +896,7 @@ func TestRepository_Predecessors(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         5,
 				Digest:       digest.FromString("5"),
 				ArtifactType: "application/vnd.test",
@@ -984,13 +983,13 @@ func TestRepository_Referrers(t *testing.T) {
 	referrerSet := [][]ocispec.Descriptor{
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         1,
 				Digest:       digest.FromString("1"),
 				ArtifactType: "application/vnd.test",
 			},
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         2,
 				Digest:       digest.FromString("2"),
 				ArtifactType: "application/vnd.test",
@@ -998,13 +997,13 @@ func TestRepository_Referrers(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         3,
 				Digest:       digest.FromString("3"),
 				ArtifactType: "application/vnd.test",
 			},
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         4,
 				Digest:       digest.FromString("4"),
 				ArtifactType: "application/vnd.test",
@@ -1012,7 +1011,7 @@ func TestRepository_Referrers(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         5,
 				Digest:       digest.FromString("5"),
 				ArtifactType: "application/vnd.test",
@@ -1194,13 +1193,13 @@ func TestRepository_Referrers_Fallback(t *testing.T) {
 	referrerSet := [][]ocispec.Descriptor{
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         1,
 				Digest:       digest.FromString("1"),
 				ArtifactType: "application/vnd.test",
 			},
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         2,
 				Digest:       digest.FromString("2"),
 				ArtifactType: "application/vnd.test",
@@ -1208,13 +1207,13 @@ func TestRepository_Referrers_Fallback(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         3,
 				Digest:       digest.FromString("3"),
 				ArtifactType: "application/vnd.test",
 			},
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         4,
 				Digest:       digest.FromString("4"),
 				ArtifactType: "application/vnd.test",
@@ -1222,7 +1221,7 @@ func TestRepository_Referrers_Fallback(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         5,
 				Digest:       digest.FromString("5"),
 				ArtifactType: "application/vnd.test",
@@ -1303,13 +1302,13 @@ func TestRepository_Referrers_ServerFiltering(t *testing.T) {
 	referrerSet := [][]ocispec.Descriptor{
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         1,
 				Digest:       digest.FromString("1"),
 				ArtifactType: "application/vnd.test",
 			},
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         2,
 				Digest:       digest.FromString("2"),
 				ArtifactType: "application/vnd.test",
@@ -1317,13 +1316,13 @@ func TestRepository_Referrers_ServerFiltering(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         3,
 				Digest:       digest.FromString("3"),
 				ArtifactType: "application/vnd.test",
 			},
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         4,
 				Digest:       digest.FromString("4"),
 				ArtifactType: "application/vnd.test",
@@ -1331,7 +1330,7 @@ func TestRepository_Referrers_ServerFiltering(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         5,
 				Digest:       digest.FromString("5"),
 				ArtifactType: "application/vnd.test",
@@ -1422,13 +1421,13 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 	referrerSet := [][]ocispec.Descriptor{
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         1,
 				Digest:       digest.FromString("1"),
 				ArtifactType: "application/vnd.test",
 			},
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         2,
 				Digest:       digest.FromString("2"),
 				ArtifactType: "application/vnd.foo",
@@ -1436,13 +1435,13 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         3,
 				Digest:       digest.FromString("3"),
 				ArtifactType: "application/vnd.test",
 			},
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         4,
 				Digest:       digest.FromString("4"),
 				ArtifactType: "application/vnd.bar",
@@ -1450,7 +1449,7 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         5,
 				Digest:       digest.FromString("5"),
 				ArtifactType: "application/vnd.baz",
@@ -1460,7 +1459,7 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 	filteredReferrerSet := [][]ocispec.Descriptor{
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         1,
 				Digest:       digest.FromString("1"),
 				ArtifactType: "application/vnd.test",
@@ -1468,7 +1467,7 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 		},
 		{
 			{
-				MediaType:    artifactspec.MediaTypeArtifactManifest,
+				MediaType:    ocispec.MediaTypeArtifactManifest,
 				Size:         3,
 				Digest:       digest.FromString("3"),
 				ArtifactType: "application/vnd.test",
@@ -1552,31 +1551,31 @@ func TestRepository_Referrers_ClientFiltering(t *testing.T) {
 func Test_filterReferrers(t *testing.T) {
 	refs := []ocispec.Descriptor{
 		{
-			MediaType:    artifactspec.MediaTypeArtifactManifest,
+			MediaType:    ocispec.MediaTypeArtifactManifest,
 			Size:         1,
 			Digest:       digest.FromString("1"),
 			ArtifactType: "application/vnd.test",
 		},
 		{
-			MediaType:    artifactspec.MediaTypeArtifactManifest,
+			MediaType:    ocispec.MediaTypeArtifactManifest,
 			Size:         2,
 			Digest:       digest.FromString("2"),
 			ArtifactType: "application/vnd.foo",
 		},
 		{
-			MediaType:    artifactspec.MediaTypeArtifactManifest,
+			MediaType:    ocispec.MediaTypeArtifactManifest,
 			Size:         3,
 			Digest:       digest.FromString("3"),
 			ArtifactType: "application/vnd.bar",
 		},
 		{
-			MediaType:    artifactspec.MediaTypeArtifactManifest,
+			MediaType:    ocispec.MediaTypeArtifactManifest,
 			Size:         4,
 			Digest:       digest.FromString("4"),
 			ArtifactType: "application/vnd.test",
 		},
 		{
-			MediaType:    artifactspec.MediaTypeArtifactManifest,
+			MediaType:    ocispec.MediaTypeArtifactManifest,
 			Size:         5,
 			Digest:       digest.FromString("5"),
 			ArtifactType: "application/vnd.baz",
@@ -1585,13 +1584,13 @@ func Test_filterReferrers(t *testing.T) {
 	got := filterReferrers(refs, "application/vnd.test")
 	want := []ocispec.Descriptor{
 		{
-			MediaType:    artifactspec.MediaTypeArtifactManifest,
+			MediaType:    ocispec.MediaTypeArtifactManifest,
 			Size:         1,
 			Digest:       digest.FromString("1"),
 			ArtifactType: "application/vnd.test",
 		},
 		{
-			MediaType:    artifactspec.MediaTypeArtifactManifest,
+			MediaType:    ocispec.MediaTypeArtifactManifest,
 			Size:         4,
 			Digest:       digest.FromString("4"),
 			ArtifactType: "application/vnd.test",
@@ -1605,19 +1604,19 @@ func Test_filterReferrers(t *testing.T) {
 func Test_filterReferrers_allMatch(t *testing.T) {
 	refs := []ocispec.Descriptor{
 		{
-			MediaType:    artifactspec.MediaTypeArtifactManifest,
+			MediaType:    ocispec.MediaTypeArtifactManifest,
 			Size:         1,
 			Digest:       digest.FromString("1"),
 			ArtifactType: "application/vnd.test",
 		},
 		{
-			MediaType:    artifactspec.MediaTypeArtifactManifest,
+			MediaType:    ocispec.MediaTypeArtifactManifest,
 			Size:         4,
 			Digest:       digest.FromString("2"),
 			ArtifactType: "application/vnd.test",
 		},
 		{
-			MediaType:    artifactspec.MediaTypeArtifactManifest,
+			MediaType:    ocispec.MediaTypeArtifactManifest,
 			Size:         5,
 			Digest:       digest.FromString("3"),
 			ArtifactType: "application/vnd.test",


### PR DESCRIPTION
1. Add support for `ocispec.MediaTypeArtifactManifest` and `ocispec.Artifact`
2. Replace `artifactspec.Manifest` with `ocispec.MediaTypeArtifactManifest` in tests
3. Refactors related to `Pack` and `ExtendedCopy` will come in later PRs

Related to https://github.com/oras-project/oras-go/issues/308
Signed-off-by: Sylvia Lei <lixlei@microsoft.com>