### PR TITLE
refactor: optimize filters for `oras.ExtendedCopy`

### DIFF
--- a/extendedcopy.go
+++ b/extendedcopy.go
@@ -292,7 +292,7 @@ func (opts *ExtendedCopyGraphOptions) FilterArtifactType(regex *regexp.Regexp) {
 			// However, the descriptors returned by Predecessors may not include
 			// the artifact type of the corresponding manifests.
 			for i, p := range predecessors {
-				if p.ArtifactType == "" && p.MediaType == ocispec.MediaTypeArtifactManifest {
+				if p.MediaType == ocispec.MediaTypeArtifactManifest && p.ArtifactType == "" {
 					// if the artifact type is not present in the descriptors,
 					// fetch it from the manifest content.
 					artifactType, err := fetchArtifactType(ctx, src, p)

--- a/extendedcopy.go
+++ b/extendedcopy.go
@@ -195,11 +195,11 @@ func (opts *ExtendedCopyGraphOptions) FilterAnnotation(key string, regex *regexp
 		var predecessors []ocispec.Descriptor
 		var err error
 
-		rf, supportReferrers := src.(registry.ReferrerFinder)
+		referrerFinder, supportReferrers := src.(registry.ReferrerFinder)
 		if fp == nil {
 			if supportReferrers {
 				// if src is a ReferrerFinder, use Referrers() for possible memory saving
-				if err := rf.Referrers(ctx, desc, "", func(referrers []ocispec.Descriptor) error {
+				if err := referrerFinder.Referrers(ctx, desc, "", func(referrers []ocispec.Descriptor) error {
 					// for each page of the results, filter the referrers
 					predecessors = filter(predecessors, referrers)
 					return nil
@@ -265,11 +265,11 @@ func (opts *ExtendedCopyGraphOptions) FilterArtifactType(regex *regexp.Regexp) {
 	opts.FindPredecessors = func(ctx context.Context, src content.ReadOnlyGraphStorage, desc ocispec.Descriptor) ([]ocispec.Descriptor, error) {
 		var predecessors []ocispec.Descriptor
 		var err error
-		rf, supportReferrers := src.(registry.ReferrerFinder)
+		referrerFinder, supportReferrers := src.(registry.ReferrerFinder)
 		if fp == nil {
 			if supportReferrers {
 				// if src is a ReferrerFinder, use Referrers() for possible memory saving
-				if err := rf.Referrers(ctx, desc, "", func(referrers []ocispec.Descriptor) error {
+				if err := referrerFinder.Referrers(ctx, desc, "", func(referrers []ocispec.Descriptor) error {
 					// for each page of the results, filter the referrers
 					predecessors = filter(predecessors, referrers)
 					return nil

--- a/extendedcopy_test.go
+++ b/extendedcopy_test.go
@@ -804,6 +804,75 @@ func TestExtendedCopyGraph_FilterAnnotationWithMultipleRegex(t *testing.T) {
 	verifyCopy(dst, copiedIndice, uncopiedIndice)
 }
 
+func TestExtendedCopyGraph_FilterAnnotationWithRegexNoAnnotationInDescriptor(t *testing.T) {
+	// generate test content
+	var blobs [][]byte
+	var descs []ocispec.Descriptor
+	appendBlob := func(mediaType string, blob []byte) {
+		blobs = append(blobs, blob)
+		descs = append(descs, ocispec.Descriptor{
+			MediaType: mediaType,
+			Digest:    digest.FromBytes(blob),
+			Size:      int64(len(blob)),
+		})
+	}
+	generateArtifactManifest := func(subject ocispec.Descriptor, key string, value string) {
+		manifest := ocispec.Artifact{
+			MediaType:   ocispec.MediaTypeArtifactManifest,
+			Subject:     &subject,
+			Annotations: map[string]string{key: value},
+		}
+		manifestJSON, err := json.Marshal(manifest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
+	}
+	appendBlob(ocispec.MediaTypeImageLayer, []byte("foo"))   // descs[0]
+	generateArtifactManifest(descs[0], "bar", "bluebrown")   // descs[1]
+	generateArtifactManifest(descs[0], "bar", "blackred")    // descs[2]
+	generateArtifactManifest(descs[0], "bar", "blackviolet") // descs[3]
+	generateArtifactManifest(descs[0], "bar", "greengrey")   // descs[4]
+	generateArtifactManifest(descs[0], "bar", "brownblack")  // descs[5]
+	ctx := context.Background()
+	verifyCopy := func(dst content.Fetcher, copiedIndice []int, uncopiedIndice []int) {
+		for _, i := range copiedIndice {
+			got, err := content.FetchAll(ctx, dst, descs[i])
+			if err != nil {
+				t.Errorf("content[%d] error = %v, wantErr %v", i, err, false)
+				continue
+			}
+			if want := blobs[i]; !bytes.Equal(got, want) {
+				t.Errorf("content[%d] = %v, want %v", i, got, want)
+			}
+		}
+		for _, i := range uncopiedIndice {
+			if _, err := content.FetchAll(ctx, dst, descs[i]); !errors.Is(err, errdef.ErrNotFound) {
+				t.Errorf("content[%d] error = %v, wantErr %v", i, err, errdef.ErrNotFound)
+			}
+		}
+	}
+	src := memory.New()
+	for i := range blobs {
+		err := src.Push(ctx, descs[i], bytes.NewReader(blobs[i]))
+		if err != nil {
+			t.Fatalf("failed to push test content to src: %d: %v", i, err)
+		}
+	}
+	// test extended copy by descs[0] with annotation filter
+	dst := memory.New()
+	opts := oras.ExtendedCopyGraphOptions{}
+	exp := "black."
+	regex := regexp.MustCompile(exp)
+	opts.FilterAnnotation("bar", regex)
+	if err := oras.ExtendedCopyGraph(ctx, src, dst, descs[0], opts); err != nil {
+		t.Fatalf("ExtendedCopyGraph() error = %v, wantErr %v", err, false)
+	}
+	copiedIndice := []int{0, 2, 3}
+	uncopiedIndice := []int{1, 4, 5}
+	verifyCopy(dst, copiedIndice, uncopiedIndice)
+}
+
 func TestExtendedCopyGraph_FilterArtifactTypeWithRegex(t *testing.T) {
 	// generate test content
 	var blobs [][]byte

--- a/extendedcopy_test.go
+++ b/extendedcopy_test.go
@@ -604,13 +604,12 @@ func TestExtendedCopyGraph_FilterAnnotationWithRegex(t *testing.T) {
 	// generate test content
 	var blobs [][]byte
 	var descs []ocispec.Descriptor
-	appendBlob := func(mediaType string, blob []byte, key string, value string) {
+	appendBlob := func(mediaType string, blob []byte) {
 		blobs = append(blobs, blob)
 		descs = append(descs, ocispec.Descriptor{
-			MediaType:   mediaType,
-			Digest:      digest.FromBytes(blob),
-			Size:        int64(len(blob)),
-			Annotations: map[string]string{key: value},
+			MediaType: mediaType,
+			Digest:    digest.FromBytes(blob),
+			Size:      int64(len(blob)),
 		})
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, key string, value string) {
@@ -623,14 +622,14 @@ func TestExtendedCopyGraph_FilterAnnotationWithRegex(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON, key, value)
+		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
 	}
-	appendBlob(ocispec.MediaTypeImageLayer, []byte("foo"), "bar", "blackpink") // descs[0]
-	generateArtifactManifest(descs[0], "bar", "bluebrown")                     // descs[1]
-	generateArtifactManifest(descs[0], "bar", "blackred")                      // descs[2]
-	generateArtifactManifest(descs[0], "bar", "blackviolet")                   // descs[3]
-	generateArtifactManifest(descs[0], "bar", "greengrey")                     // descs[4]
-	generateArtifactManifest(descs[0], "bar", "brownblack")                    // descs[5]
+	appendBlob(ocispec.MediaTypeImageLayer, []byte("foo"))   // descs[0]
+	generateArtifactManifest(descs[0], "bar", "bluebrown")   // descs[1]
+	generateArtifactManifest(descs[0], "bar", "blackred")    // descs[2]
+	generateArtifactManifest(descs[0], "bar", "blackviolet") // descs[3]
+	generateArtifactManifest(descs[0], "bar", "greengrey")   // descs[4]
+	generateArtifactManifest(descs[0], "bar", "brownblack")  // descs[5]
 	ctx := context.Background()
 	verifyCopy := func(dst content.Fetcher, copiedIndice []int, uncopiedIndice []int) {
 		for _, i := range copiedIndice {
@@ -701,13 +700,12 @@ func TestExtendedCopyGraph_FilterAnnotationWithMultipleRegex(t *testing.T) {
 	// generate test content
 	var blobs [][]byte
 	var descs []ocispec.Descriptor
-	appendBlob := func(mediaType string, blob []byte, key string, value string) {
+	appendBlob := func(mediaType string, blob []byte) {
 		blobs = append(blobs, blob)
 		descs = append(descs, ocispec.Descriptor{
-			MediaType:   mediaType,
-			Digest:      digest.FromBytes(blob),
-			Size:        int64(len(blob)),
-			Annotations: map[string]string{key: value},
+			MediaType: mediaType,
+			Digest:    digest.FromBytes(blob),
+			Size:      int64(len(blob)),
 		})
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, key string, value string) {
@@ -720,15 +718,15 @@ func TestExtendedCopyGraph_FilterAnnotationWithMultipleRegex(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON, key, value)
+		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
 	}
-	appendBlob(ocispec.MediaTypeImageLayer, []byte("foo"), "bar", "blackpink") // descs[0]
-	generateArtifactManifest(descs[0], "bar", "bluebrown")                     // descs[1]
-	generateArtifactManifest(descs[0], "bar", "blackred")                      // descs[2]
-	generateArtifactManifest(descs[0], "bar", "blackviolet")                   // descs[3]
-	generateArtifactManifest(descs[0], "bar", "greengrey")                     // descs[4]
-	generateArtifactManifest(descs[0], "bar", "brownblack")                    // descs[5]
-	generateArtifactManifest(descs[0], "bar", "blackblack")                    // descs[6]
+	appendBlob(ocispec.MediaTypeImageLayer, []byte("foo"))   // descs[0]
+	generateArtifactManifest(descs[0], "bar", "bluebrown")   // descs[1]
+	generateArtifactManifest(descs[0], "bar", "blackred")    // descs[2]
+	generateArtifactManifest(descs[0], "bar", "blackviolet") // descs[3]
+	generateArtifactManifest(descs[0], "bar", "greengrey")   // descs[4]
+	generateArtifactManifest(descs[0], "bar", "brownblack")  // descs[5]
+	generateArtifactManifest(descs[0], "bar", "blackblack")  // descs[6]
 	ctx := context.Background()
 	verifyCopy := func(dst content.Fetcher, copiedIndice []int, uncopiedIndice []int) {
 		for _, i := range copiedIndice {
@@ -804,16 +802,17 @@ func TestExtendedCopyGraph_FilterAnnotationWithMultipleRegex(t *testing.T) {
 	verifyCopy(dst, copiedIndice, uncopiedIndice)
 }
 
-func TestExtendedCopyGraph_FilterAnnotationWithRegex_NoAnnotationInDescriptor(t *testing.T) {
+func TestExtendedCopyGraph_FilterAnnotationWithRegex_AnnotationInDescriptor(t *testing.T) {
 	// generate test content
 	var blobs [][]byte
 	var descs []ocispec.Descriptor
-	appendBlob := func(mediaType string, blob []byte) {
+	appendBlob := func(mediaType, key, value string, blob []byte) {
 		blobs = append(blobs, blob)
 		descs = append(descs, ocispec.Descriptor{
-			MediaType: mediaType,
-			Digest:    digest.FromBytes(blob),
-			Size:      int64(len(blob)),
+			MediaType:   mediaType,
+			Digest:      digest.FromBytes(blob),
+			Size:        int64(len(blob)),
+			Annotations: map[string]string{key: value},
 		})
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, key string, value string) {
@@ -826,14 +825,14 @@ func TestExtendedCopyGraph_FilterAnnotationWithRegex_NoAnnotationInDescriptor(t 
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(ocispec.MediaTypeArtifactManifest, key, value, manifestJSON)
 	}
-	appendBlob(ocispec.MediaTypeImageLayer, []byte("foo"))   // descs[0]
-	generateArtifactManifest(descs[0], "bar", "bluebrown")   // descs[1]
-	generateArtifactManifest(descs[0], "bar", "blackred")    // descs[2]
-	generateArtifactManifest(descs[0], "bar", "blackviolet") // descs[3]
-	generateArtifactManifest(descs[0], "bar", "greengrey")   // descs[4]
-	generateArtifactManifest(descs[0], "bar", "brownblack")  // descs[5]
+	appendBlob(ocispec.MediaTypeImageLayer, "", "", []byte("foo")) // descs[0]
+	generateArtifactManifest(descs[0], "bar", "bluebrown")         // descs[1]
+	generateArtifactManifest(descs[0], "bar", "blackred")          // descs[2]
+	generateArtifactManifest(descs[0], "bar", "blackviolet")       // descs[3]
+	generateArtifactManifest(descs[0], "bar", "greengrey")         // descs[4]
+	generateArtifactManifest(descs[0], "bar", "brownblack")        // descs[5]
 	ctx := context.Background()
 	verifyCopy := func(dst content.Fetcher, copiedIndice []int, uncopiedIndice []int) {
 		for _, i := range copiedIndice {
@@ -873,17 +872,184 @@ func TestExtendedCopyGraph_FilterAnnotationWithRegex_NoAnnotationInDescriptor(t 
 	verifyCopy(dst, copiedIndice, uncopiedIndice)
 }
 
+func TestExtendedCopyGraph_FilterAnnotationWithMultipleRegex_Referrers(t *testing.T) {
+	// generate test content
+	var blobs [][]byte
+	var descs []ocispec.Descriptor
+	appendBlob := func(mediaType, key, value string, blob []byte) {
+		blobs = append(blobs, blob)
+		descs = append(descs, ocispec.Descriptor{
+			MediaType:   mediaType,
+			Digest:      digest.FromBytes(blob),
+			Size:        int64(len(blob)),
+			Annotations: map[string]string{key: value},
+		})
+	}
+	generateArtifactManifest := func(subject ocispec.Descriptor, key string, value string) {
+		manifest := ocispec.Artifact{
+			MediaType:   ocispec.MediaTypeArtifactManifest,
+			Subject:     &subject,
+			Annotations: map[string]string{key: value},
+		}
+		manifestJSON, err := json.Marshal(manifest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		appendBlob(ocispec.MediaTypeArtifactManifest, key, value, manifestJSON)
+	}
+	appendBlob(ocispec.MediaTypeImageLayer, "", "", []byte("foo")) // descs[0]
+	generateArtifactManifest(descs[0], "bar", "bluebrown")         // descs[1]
+	generateArtifactManifest(descs[0], "bar", "blackred")          // descs[2]
+	generateArtifactManifest(descs[0], "bar", "blackviolet")       // descs[3]
+	generateArtifactManifest(descs[0], "bar", "greengrey")         // descs[4]
+	generateArtifactManifest(descs[0], "bar", "brownblack")        // descs[5]
+	generateArtifactManifest(descs[0], "bar", "blackblack")        // descs[6]
+
+	// set up test server
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := r.URL.Path
+		w.Header().Set("ORAS-Api-Version", "oras/1.0")
+		switch {
+		case strings.Contains(p, descs[0].Digest.String()):
+			w.Header().Set("Content-Type", ocispec.MediaTypeImageLayer)
+			w.Header().Set("Content-Digest", descs[0].Digest.String())
+			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[0])))
+			w.Write(blobs[0])
+		case strings.Contains(p, descs[1].Digest.String()):
+			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Digest", descs[1].Digest.String())
+			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[1])))
+			w.Write(blobs[1])
+		case strings.Contains(p, descs[2].Digest.String()):
+			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Digest", descs[2].Digest.String())
+			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[2])))
+			w.Write(blobs[2])
+		case strings.Contains(p, descs[3].Digest.String()):
+			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Digest", descs[3].Digest.String())
+			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[3])))
+			w.Write(blobs[3])
+		case strings.Contains(p, descs[4].Digest.String()):
+			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Digest", descs[4].Digest.String())
+			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[4])))
+			w.Write(blobs[4])
+		case strings.Contains(p, descs[5].Digest.String()):
+			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Digest", descs[5].Digest.String())
+			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[5])))
+			w.Write(blobs[5])
+		case strings.Contains(p, "referrers"):
+			q := r.URL.Query()
+			var referrers []ocispec.Descriptor
+			if q.Get("digest") == descs[0].Digest.String() {
+				referrers = descs[1:]
+			}
+			result := struct {
+				Referrers []ocispec.Descriptor `json:"referrers"`
+			}{
+				Referrers: referrers,
+			}
+			if err := json.NewEncoder(w).Encode(result); err != nil {
+				t.Errorf("failed to write response: %v", err)
+			}
+		default:
+			t.Errorf("unexpected access: %s %s", r.Method, r.URL)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer ts.Close()
+	uri, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Errorf("invalid test http server: %v", err)
+	}
+
+	ctx := context.Background()
+	verifyCopy := func(dst content.Fetcher, copiedIndice []int, uncopiedIndice []int) {
+		for _, i := range copiedIndice {
+			got, err := content.FetchAll(ctx, dst, descs[i])
+			if err != nil {
+				t.Errorf("content[%d] error = %v, wantErr %v", i, err, false)
+				continue
+			}
+			if want := blobs[i]; !bytes.Equal(got, want) {
+				t.Errorf("content[%d] = %v, want %v", i, got, want)
+			}
+		}
+		for _, i := range uncopiedIndice {
+			if _, err := content.FetchAll(ctx, dst, descs[i]); !errors.Is(err, errdef.ErrNotFound) {
+				t.Errorf("content[%d] error = %v, wantErr %v", i, err, errdef.ErrNotFound)
+			}
+		}
+	}
+
+	src, err := remote.NewRepository(uri.Host + "/test")
+	if err != nil {
+		t.Errorf("NewRepository() error = %v", err)
+	}
+
+	// test extended copy by descs[0] with two annotation filters
+	dst := memory.New()
+	opts := oras.ExtendedCopyGraphOptions{}
+	exp1 := "black."
+	exp2 := ".pink|red"
+	regex1 := regexp.MustCompile(exp1)
+	regex2 := regexp.MustCompile(exp2)
+	opts.FilterAnnotation("bar", regex1)
+	opts.FilterAnnotation("bar", regex2)
+	if err := oras.ExtendedCopyGraph(ctx, src, dst, descs[0], opts); err != nil {
+		t.Fatalf("ExtendedCopyGraph() error = %v, wantErr %v", err, false)
+	}
+	copiedIndice := []int{0, 2}
+	uncopiedIndice := []int{1, 3, 4, 5, 6}
+	verifyCopy(dst, copiedIndice, uncopiedIndice)
+
+	// test extended copy by descs[0] with three annotation filters, nil included
+	dst = memory.New()
+	opts = oras.ExtendedCopyGraphOptions{}
+	exp1 = "black."
+	exp2 = ".pink|red"
+	regex1 = regexp.MustCompile(exp1)
+	regex2 = regexp.MustCompile(exp2)
+	opts.FilterAnnotation("bar", regex1)
+	opts.FilterAnnotation("bar", nil)
+	opts.FilterAnnotation("bar", regex2)
+	if err := oras.ExtendedCopyGraph(ctx, src, dst, descs[0], opts); err != nil {
+		t.Fatalf("ExtendedCopyGraph() error = %v, wantErr %v", err, false)
+	}
+	copiedIndice = []int{0, 2}
+	uncopiedIndice = []int{1, 3, 4, 5, 6}
+	verifyCopy(dst, copiedIndice, uncopiedIndice)
+
+	// test extended copy by descs[0] with two annotation filters, the second filter has an unavailable key
+	dst = memory.New()
+	opts = oras.ExtendedCopyGraphOptions{}
+	exp1 = "black."
+	exp2 = ".pink|red"
+	regex1 = regexp.MustCompile(exp1)
+	regex2 = regexp.MustCompile(exp2)
+	opts.FilterAnnotation("bar", regex1)
+	opts.FilterAnnotation("test", regex2)
+	if err := oras.ExtendedCopyGraph(ctx, src, dst, descs[0], opts); err != nil {
+		t.Fatalf("ExtendedCopyGraph() error = %v, wantErr %v", err, false)
+	}
+	copiedIndice = []int{0}
+	uncopiedIndice = []int{1, 2, 3, 4, 5, 6}
+	verifyCopy(dst, copiedIndice, uncopiedIndice)
+}
+
 func TestExtendedCopyGraph_FilterArtifactTypeWithRegex(t *testing.T) {
 	// generate test content
 	var blobs [][]byte
 	var descs []ocispec.Descriptor
-	appendBlob := func(mediaType string, artifactType string, blob []byte) {
+	appendBlob := func(mediaType string, blob []byte) {
 		blobs = append(blobs, blob)
 		descs = append(descs, ocispec.Descriptor{
-			MediaType:    mediaType,
-			ArtifactType: artifactType,
-			Digest:       digest.FromBytes(blob),
-			Size:         int64(len(blob)),
+			MediaType: mediaType,
+			Digest:    digest.FromBytes(blob),
+			Size:      int64(len(blob)),
 		})
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, artifactType string) {
@@ -896,15 +1062,15 @@ func TestExtendedCopyGraph_FilterArtifactTypeWithRegex(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(ocispec.MediaTypeArtifactManifest, artifactType, manifestJSON)
+		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
 	}
 
-	appendBlob(ocispec.MediaTypeImageConfig, "", []byte("foo")) // descs[0]
-	generateArtifactManifest(descs[0], "good-bar-yellow")       // descs[1]
-	generateArtifactManifest(descs[0], "bad-woo-red")           // descs[2]
-	generateArtifactManifest(descs[0], "bad-bar-blue")          // descs[3]
-	generateArtifactManifest(descs[0], "bad-bar-red")           // descs[4]
-	generateArtifactManifest(descs[0], "good-woo-pink")         // descs[5]
+	appendBlob(ocispec.MediaTypeImageLayer, []byte("foo")) // descs[0]
+	generateArtifactManifest(descs[0], "good-bar-yellow")  // descs[1]
+	generateArtifactManifest(descs[0], "bad-woo-red")      // descs[2]
+	generateArtifactManifest(descs[0], "bad-bar-blue")     // descs[3]
+	generateArtifactManifest(descs[0], "bad-bar-red")      // descs[4]
+	generateArtifactManifest(descs[0], "good-woo-pink")    // descs[5]
 
 	ctx := context.Background()
 	verifyCopy := func(dst content.Fetcher, copiedIndice []int, uncopiedIndice []int) {
@@ -960,13 +1126,12 @@ func TestExtendedCopyGraph_FilterArtifactTypeWithMultipleRegex(t *testing.T) {
 	// generate test content
 	var blobs [][]byte
 	var descs []ocispec.Descriptor
-	appendBlob := func(mediaType string, artifactType string, blob []byte) {
+	appendBlob := func(mediaType string, blob []byte) {
 		blobs = append(blobs, blob)
 		descs = append(descs, ocispec.Descriptor{
-			MediaType:    mediaType,
-			ArtifactType: artifactType,
-			Digest:       digest.FromBytes(blob),
-			Size:         int64(len(blob)),
+			MediaType: mediaType,
+			Digest:    digest.FromBytes(blob),
+			Size:      int64(len(blob)),
 		})
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, artifactType string) {
@@ -979,14 +1144,14 @@ func TestExtendedCopyGraph_FilterArtifactTypeWithMultipleRegex(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(ocispec.MediaTypeArtifactManifest, artifactType, manifestJSON)
+		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
 	}
-	appendBlob(ocispec.MediaTypeImageConfig, "", []byte("foo")) // descs[0]
-	generateArtifactManifest(descs[0], "good-bar-yellow")       // descs[1]
-	generateArtifactManifest(descs[0], "bad-woo-red")           // descs[2]
-	generateArtifactManifest(descs[0], "bad-bar-blue")          // descs[3]
-	generateArtifactManifest(descs[0], "bad-bar-red")           // descs[4]
-	generateArtifactManifest(descs[0], "good-woo-pink")         // descs[5]
+	appendBlob(ocispec.MediaTypeImageLayer, []byte("foo")) // descs[0]
+	generateArtifactManifest(descs[0], "good-bar-yellow")  // descs[1]
+	generateArtifactManifest(descs[0], "bad-woo-red")      // descs[2]
+	generateArtifactManifest(descs[0], "bad-bar-blue")     // descs[3]
+	generateArtifactManifest(descs[0], "bad-bar-red")      // descs[4]
+	generateArtifactManifest(descs[0], "good-woo-pink")    // descs[5]
 
 	ctx := context.Background()
 	verifyCopy := func(dst content.Fetcher, copiedIndice []int, uncopiedIndice []int) {
@@ -1051,16 +1216,17 @@ func TestExtendedCopyGraph_FilterArtifactTypeWithMultipleRegex(t *testing.T) {
 	verifyCopy(dst, copiedIndice, uncopiedIndice)
 }
 
-func TestExtendedCopyGraph_FilterArtifactTypeWithRegex_NoArtifactTypeInDescriptor(t *testing.T) {
+func TestExtendedCopyGraph_FilterArtifactTypeWithRegex_ArtifactTypeInDescriptor(t *testing.T) {
 	// generate test content
 	var blobs [][]byte
 	var descs []ocispec.Descriptor
-	appendBlob := func(mediaType string, blob []byte) {
+	appendBlob := func(mediaType string, artifactType string, blob []byte) {
 		blobs = append(blobs, blob)
 		descs = append(descs, ocispec.Descriptor{
-			MediaType: mediaType,
-			Digest:    digest.FromBytes(blob),
-			Size:      int64(len(blob)),
+			MediaType:    mediaType,
+			ArtifactType: artifactType,
+			Digest:       digest.FromBytes(blob),
+			Size:         int64(len(blob)),
 		})
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, artifactType string) {
@@ -1073,15 +1239,15 @@ func TestExtendedCopyGraph_FilterArtifactTypeWithRegex_NoArtifactTypeInDescripto
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
+		appendBlob(ocispec.MediaTypeArtifactManifest, artifactType, manifestJSON)
 	}
 
-	appendBlob(ocispec.MediaTypeImageConfig, []byte("foo")) // descs[0]
-	generateArtifactManifest(descs[0], "good-bar-yellow")   // descs[1]
-	generateArtifactManifest(descs[0], "bad-woo-red")       // descs[2]
-	generateArtifactManifest(descs[0], "bad-bar-blue")      // descs[3]
-	generateArtifactManifest(descs[0], "bad-bar-red")       // descs[4]
-	generateArtifactManifest(descs[0], "good-woo-pink")     // descs[5]
+	appendBlob(ocispec.MediaTypeImageLayer, "", []byte("foo")) // descs[0]
+	generateArtifactManifest(descs[0], "good-bar-yellow")      // descs[1]
+	generateArtifactManifest(descs[0], "bad-woo-red")          // descs[2]
+	generateArtifactManifest(descs[0], "bad-bar-blue")         // descs[3]
+	generateArtifactManifest(descs[0], "bad-bar-red")          // descs[4]
+	generateArtifactManifest(descs[0], "good-woo-pink")        // descs[5]
 
 	ctx := context.Background()
 	verifyCopy := func(dst content.Fetcher, copiedIndice []int, uncopiedIndice []int) {
@@ -1133,7 +1299,7 @@ func TestExtendedCopyGraph_FilterArtifactTypeWithRegex_NoArtifactTypeInDescripto
 	}
 }
 
-func TestExtendedCopyGraph_FilterArtifactTypeByReferrersWithMultipleRegex(t *testing.T) {
+func TestExtendedCopyGraph_FilterArtifactTypeWithMultipleRegex_Referrers(t *testing.T) {
 	// generate test content
 	var blobs [][]byte
 	var descs []ocispec.Descriptor
@@ -1159,12 +1325,12 @@ func TestExtendedCopyGraph_FilterArtifactTypeByReferrersWithMultipleRegex(t *tes
 		appendBlob(ocispec.MediaTypeArtifactManifest, artifactType, manifestJSON)
 	}
 
-	appendBlob(ocispec.MediaTypeImageConfig, "", []byte("foo")) // descs[0]
-	generateArtifactManifest(descs[0], "good-bar-yellow")       // descs[1]
-	generateArtifactManifest(descs[0], "bad-woo-red")           // descs[2]
-	generateArtifactManifest(descs[0], "bad-bar-blue")          // descs[3]
-	generateArtifactManifest(descs[0], "bad-bar-red")           // descs[4]
-	generateArtifactManifest(descs[0], "good-woo-pink")         // descs[5]
+	appendBlob(ocispec.MediaTypeImageLayer, "", []byte("foo")) // descs[0]
+	generateArtifactManifest(descs[0], "good-bar-yellow")      // descs[1]
+	generateArtifactManifest(descs[0], "bad-woo-red")          // descs[2]
+	generateArtifactManifest(descs[0], "bad-bar-blue")         // descs[3]
+	generateArtifactManifest(descs[0], "bad-bar-red")          // descs[4]
+	generateArtifactManifest(descs[0], "good-woo-pink")        // descs[5]
 
 	// set up test server
 	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1172,7 +1338,7 @@ func TestExtendedCopyGraph_FilterArtifactTypeByReferrersWithMultipleRegex(t *tes
 		w.Header().Set("ORAS-Api-Version", "oras/1.0")
 		switch {
 		case strings.Contains(p, descs[0].Digest.String()):
-			w.Header().Set("Content-Type", ocispec.MediaTypeImageConfig)
+			w.Header().Set("Content-Type", ocispec.MediaTypeImageLayer)
 			w.Header().Set("Content-Digest", descs[0].Digest.String())
 			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[0])))
 			w.Write(blobs[0])
@@ -1273,14 +1439,12 @@ func TestExtendedCopyGraph_FilterArtifactTypeAndAnnotationWithMultipleRegex(t *t
 	// generate test content
 	var blobs [][]byte
 	var descs []ocispec.Descriptor
-	appendBlob := func(mediaType string, artifactType string, blob []byte, value string) {
+	appendBlob := func(mediaType string, blob []byte) {
 		blobs = append(blobs, blob)
 		descs = append(descs, ocispec.Descriptor{
-			MediaType:    mediaType,
-			ArtifactType: artifactType,
-			Digest:       digest.FromBytes(blob),
-			Size:         int64(len(blob)),
-			Annotations:  map[string]string{"rank": value},
+			MediaType: mediaType,
+			Digest:    digest.FromBytes(blob),
+			Size:      int64(len(blob)),
 		})
 	}
 	generateArtifactManifest := func(subject ocispec.Descriptor, artifactType string, value string) {
@@ -1294,18 +1458,18 @@ func TestExtendedCopyGraph_FilterArtifactTypeAndAnnotationWithMultipleRegex(t *t
 		if err != nil {
 			t.Fatal(err)
 		}
-		appendBlob(ocispec.MediaTypeArtifactManifest, artifactType, manifestJSON, value)
+		appendBlob(ocispec.MediaTypeArtifactManifest, manifestJSON)
 	}
-	appendBlob(ocispec.MediaTypeImageConfig, "", []byte("foo"), "na") // descs[0]
-	generateArtifactManifest(descs[0], "good-bar-yellow", "1st")      // descs[1]
-	generateArtifactManifest(descs[0], "bad-woo-red", "1st")          // descs[2]
-	generateArtifactManifest(descs[0], "bad-bar-blue", "2nd")         // descs[3]
-	generateArtifactManifest(descs[0], "bad-bar-red", "3rd")          // descs[4]
-	generateArtifactManifest(descs[0], "good-woo-pink", "2nd")        // descs[5]
-	generateArtifactManifest(descs[0], "good-foo-blue", "3rd")        // descs[6]
-	generateArtifactManifest(descs[0], "bad-bar-orange", "4th")       // descs[7]
-	generateArtifactManifest(descs[0], "bad-woo-white", "4th")        // descs[8]
-	generateArtifactManifest(descs[0], "good-woo-orange", "na")       // descs[9]
+	appendBlob(ocispec.MediaTypeImageLayer, []byte("foo"))       // descs[0]
+	generateArtifactManifest(descs[0], "good-bar-yellow", "1st") // descs[1]
+	generateArtifactManifest(descs[0], "bad-woo-red", "1st")     // descs[2]
+	generateArtifactManifest(descs[0], "bad-bar-blue", "2nd")    // descs[3]
+	generateArtifactManifest(descs[0], "bad-bar-red", "3rd")     // descs[4]
+	generateArtifactManifest(descs[0], "good-woo-pink", "2nd")   // descs[5]
+	generateArtifactManifest(descs[0], "good-foo-blue", "3rd")   // descs[6]
+	generateArtifactManifest(descs[0], "bad-bar-orange", "4th")  // descs[7]
+	generateArtifactManifest(descs[0], "bad-woo-white", "4th")   // descs[8]
+	generateArtifactManifest(descs[0], "good-woo-orange", "na")  // descs[9]
 
 	ctx := context.Background()
 	verifyCopy := func(dst content.Fetcher, copiedIndice []int, uncopiedIndice []int) {
@@ -1334,6 +1498,172 @@ func TestExtendedCopyGraph_FilterArtifactTypeAndAnnotationWithMultipleRegex(t *t
 		}
 	}
 
+	// test extended copy by descs[0], include the predecessors whose artifact
+	// type and annotation match the regular expressions.
+	typeExp1 := ".foo|bar."
+	typeExp2 := "bad."
+	annotationExp1 := "[1-4]."
+	annotationExp2 := "2|4."
+	dst := memory.New()
+	opts := oras.ExtendedCopyGraphOptions{}
+	typeRegex1 := regexp.MustCompile(typeExp1)
+	typeRegex2 := regexp.MustCompile(typeExp2)
+	annotationRegex1 := regexp.MustCompile(annotationExp1)
+	annotationRegex2 := regexp.MustCompile(annotationExp2)
+	opts.FilterAnnotation("rank", annotationRegex1)
+	opts.FilterArtifactType(typeRegex1)
+	opts.FilterAnnotation("rank", annotationRegex2)
+	opts.FilterArtifactType(typeRegex2)
+	if err := oras.ExtendedCopyGraph(ctx, src, dst, descs[0], opts); err != nil {
+		t.Errorf("ExtendedCopyGraph() error = %v, wantErr %v", err, false)
+	}
+	copiedIndice := []int{0, 3, 7}
+	uncopiedIndice := []int{1, 2, 4, 5, 6, 8, 9}
+	verifyCopy(dst, copiedIndice, uncopiedIndice)
+}
+
+func TestExtendedCopyGraph_FilterArtifactTypeAndAnnotationWithMultipleRegex_Referrers(t *testing.T) {
+	// generate test content
+	var blobs [][]byte
+	var descs []ocispec.Descriptor
+	appendBlob := func(mediaType string, artifactType string, blob []byte, value string) {
+		blobs = append(blobs, blob)
+		descs = append(descs, ocispec.Descriptor{
+			MediaType:    mediaType,
+			ArtifactType: artifactType,
+			Digest:       digest.FromBytes(blob),
+			Size:         int64(len(blob)),
+			Annotations:  map[string]string{"rank": value},
+		})
+	}
+	generateArtifactManifest := func(subject ocispec.Descriptor, artifactType string, value string) {
+		manifest := ocispec.Artifact{
+			MediaType:    ocispec.MediaTypeArtifactManifest,
+			ArtifactType: artifactType,
+			Subject:      &subject,
+			Annotations:  map[string]string{"rank": value},
+		}
+		manifestJSON, err := json.Marshal(manifest)
+		if err != nil {
+			t.Fatal(err)
+		}
+		appendBlob(ocispec.MediaTypeArtifactManifest, artifactType, manifestJSON, value)
+	}
+	appendBlob(ocispec.MediaTypeImageLayer, "", []byte("foo"), "na") // descs[0]
+	generateArtifactManifest(descs[0], "good-bar-yellow", "1st")     // descs[1]
+	generateArtifactManifest(descs[0], "bad-woo-red", "1st")         // descs[2]
+	generateArtifactManifest(descs[0], "bad-bar-blue", "2nd")        // descs[3]
+	generateArtifactManifest(descs[0], "bad-bar-red", "3rd")         // descs[4]
+	generateArtifactManifest(descs[0], "good-woo-pink", "2nd")       // descs[5]
+	generateArtifactManifest(descs[0], "good-foo-blue", "3rd")       // descs[6]
+	generateArtifactManifest(descs[0], "bad-bar-orange", "4th")      // descs[7]
+	generateArtifactManifest(descs[0], "bad-woo-white", "4th")       // descs[8]
+	generateArtifactManifest(descs[0], "good-woo-orange", "na")      // descs[9]
+
+	// set up test server
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := r.URL.Path
+		w.Header().Set("ORAS-Api-Version", "oras/1.0")
+		switch {
+		case strings.Contains(p, descs[0].Digest.String()):
+			w.Header().Set("Content-Type", ocispec.MediaTypeImageLayer)
+			w.Header().Set("Content-Digest", descs[0].Digest.String())
+			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[0])))
+			w.Write(blobs[0])
+		case strings.Contains(p, descs[1].Digest.String()):
+			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Digest", descs[1].Digest.String())
+			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[1])))
+			w.Write(blobs[1])
+		case strings.Contains(p, descs[2].Digest.String()):
+			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Digest", descs[2].Digest.String())
+			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[2])))
+			w.Write(blobs[2])
+		case strings.Contains(p, descs[3].Digest.String()):
+			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Digest", descs[3].Digest.String())
+			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[3])))
+			w.Write(blobs[3])
+		case strings.Contains(p, descs[4].Digest.String()):
+			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Digest", descs[4].Digest.String())
+			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[4])))
+			w.Write(blobs[4])
+		case strings.Contains(p, descs[5].Digest.String()):
+			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Digest", descs[5].Digest.String())
+			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[5])))
+			w.Write(blobs[5])
+		case strings.Contains(p, descs[6].Digest.String()):
+			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Digest", descs[6].Digest.String())
+			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[6])))
+			w.Write(blobs[6])
+		case strings.Contains(p, descs[7].Digest.String()):
+			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Digest", descs[7].Digest.String())
+			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[7])))
+			w.Write(blobs[7])
+		case strings.Contains(p, descs[8].Digest.String()):
+			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Digest", descs[8].Digest.String())
+			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[8])))
+			w.Write(blobs[8])
+		case strings.Contains(p, descs[9].Digest.String()):
+			w.Header().Set("Content-Type", ocispec.MediaTypeArtifactManifest)
+			w.Header().Set("Content-Digest", descs[9].Digest.String())
+			w.Header().Set("Content-Length", strconv.Itoa(len(blobs[9])))
+			w.Write(blobs[9])
+		case strings.Contains(p, "referrers"):
+			q := r.URL.Query()
+			var referrers []ocispec.Descriptor
+			if q.Get("digest") == descs[0].Digest.String() {
+				referrers = descs[1:]
+			}
+			result := struct {
+				Referrers []ocispec.Descriptor `json:"referrers"`
+			}{
+				Referrers: referrers,
+			}
+			if err := json.NewEncoder(w).Encode(result); err != nil {
+				t.Errorf("failed to write response: %v", err)
+			}
+		default:
+			t.Errorf("unexpected access: %s %s", r.Method, r.URL)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer ts.Close()
+	uri, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Errorf("invalid test http server: %v", err)
+	}
+
+	ctx := context.Background()
+	verifyCopy := func(dst content.Fetcher, copiedIndice []int, uncopiedIndice []int) {
+		for _, i := range copiedIndice {
+			got, err := content.FetchAll(ctx, dst, descs[i])
+			if err != nil {
+				t.Errorf("content[%d] error = %v, wantErr %v", i, err, false)
+				continue
+			}
+			if want := blobs[i]; !bytes.Equal(got, want) {
+				t.Errorf("content[%d] = %v, want %v", i, got, want)
+			}
+		}
+		for _, i := range uncopiedIndice {
+			if _, err := content.FetchAll(ctx, dst, descs[i]); !errors.Is(err, errdef.ErrNotFound) {
+				t.Errorf("content[%d] error = %v, wantErr %v", i, err, errdef.ErrNotFound)
+			}
+		}
+	}
+
+	src, err := remote.NewRepository(uri.Host + "/test")
+	if err != nil {
+		t.Errorf("NewRepository() error = %v", err)
+	}
 	// test extended copy by descs[0], include the predecessors whose artifact
 	// type and annotation match the regular expressions.
 	typeExp1 := ".foo|bar."


### PR DESCRIPTION
According to [Open Container Initiative Distribution Specification](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers), the `Referrers` API must include the `artifactType` and `annotations` of the referrers in the returned descriptor list. (`Predecessors` also supports this)
> The descriptors MUST include an artifactType field that is set to the value of artifactType for an artifact manifest if present, or the configuration descriptor's mediaType for an image manifest. The descriptors MUST include annotations from the image or artifact manifest.

Related to https://github.com/oras-project/oras-go/issues/310
Signed-off-by: Lixia (Sylvia) Lei <lixlei@microsoft.com>